### PR TITLE
RDK-55706: Removed cec host header to resolve the error

### DIFF
--- a/HdmiCecSource/HdmiCecSourceImplementation.cpp
+++ b/HdmiCecSource/HdmiCecSourceImplementation.cpp
@@ -24,7 +24,6 @@
 #include "ccec/CECFrame.hpp"
 #include "ccec/MessageEncoder.hpp"
 #include "host.hpp"
-#include "ccec/host/RDK.hpp"
 
 #include "dsMgr.h"
 #include "dsDisplay.h"


### PR DESCRIPTION
RDK-55706: Removed cec host header to resolve the error