### PR TITLE
RDKEMW-3138: Stub for VVR support

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -65,6 +65,7 @@
 #define AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "gameFeatureStatusUpdate"
 #define AVINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED "aviContentTypeUpdate"
 
+//demo
 static bool isAudioBalanceSet = false;
 static int planeType = 0;
 

--- a/AVInput/AVInput.h
+++ b/AVInput/AVInput.h
@@ -27,6 +27,7 @@
 #define MAX_PRIM_VOL_LEVEL 100
 #define DEFAULT_INPUT_VOL_LEVEL 100
 
+//demo
 namespace WPEFramework {
 namespace Plugin {
 


### PR DESCRIPTION
Reason for change: Stub for VVR support
Test Procedure: refer the ticket
Risks: None
Signed-off-by: Neethu A S neethu.arambilsunny@sky.uk