### PR TITLE
RDK-57093: PowerManager Interface methods and event APIs modified

### DIFF
--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -306,7 +306,7 @@ namespace WPEFramework
 
         void HdcpProfile::dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
-            uint32_t res = Core::ERROR_GENERAL;
+            Core::hresult res = Core::ERROR_GENERAL;
             PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
             PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
 

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -765,7 +765,7 @@ namespace WPEFramework
            m_arcStartStopTimer.connect( std::bind( &HdmiCecSink::arcStartStopTimerFunction, this ) );
            m_arcStartStopTimer.setSingleShot(true);
             // get power state:
-            uint32_t res = Core::ERROR_GENERAL;
+            Core::hresult res = Core::ERROR_GENERAL;
             PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
             PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
 

--- a/HdmiCecSource/HdmiCecSourceImplementation.cpp
+++ b/HdmiCecSource/HdmiCecSourceImplementation.cpp
@@ -398,7 +398,7 @@ namespace WPEFramework
         ASSERT(service != nullptr);
         PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
         PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
-        uint32_t res = Core::ERROR_GENERAL;
+        Core::hresult res = Core::ERROR_GENERAL;
         string msg;
         if (Utils::IARM::init()) {
             //Initialize cecEnableStatus to false in ctor

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -160,7 +160,7 @@ namespace WPEFramework
 
 #if defined(HAS_API_POWERSTATE)
                     {
-                        uint32_t res = Core::ERROR_GENERAL;
+                        Core::hresult res = Core::ERROR_GENERAL;
                         PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
                         PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
                         ASSERT (_powerManagerPlugin);


### PR DESCRIPTION
RDK-57093: PowerManager Interface methods and event APIs modified

Reason for changes: The Interface method return type and event APIs are modified as per API spec
Test procedure: Full stack build
Risk: Low