### PR TITLE
RDKEMW-4139: Coverity integration with Entservices-inputoutput repo (…

### DIFF
--- a/cov_build.sh
+++ b/cov_build.sh
@@ -25,6 +25,7 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-inputoutput \
 -DDS_FOUND=ON \
 -DPLUGIN_HDMICECSOURCE=ON \
 -DPLUGIN_HDCPPROFILE=ON \
+-DPLUGIN_HDMICECSINK=ON \
 -DCMAKE_CXX_FLAGS="-DEXCEPTIONS_ENABLE=ON \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/audiocapturemgr \
@@ -33,6 +34,9 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-inputoutput \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/rdk/iarmmgrs-hal \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/ccec/drivers \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/network \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/thunder \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/devicesettings \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/devicesettings.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Iarm.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Rfc.h \
@@ -45,7 +49,7 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-inputoutput \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/wpa_ctrl_mock.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/secure_wrappermock.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/HdmiCec.h \
---coverage -Wall -Werror -Wno-error=format \
+-Wall -Wno-unused-result -Werror -Wno-error=format \
 -Wl,-wrap,system -Wl,-wrap,popen -Wl,-wrap,syslog \
 -DENABLE_TELEMETRY_LOGGING -DUSE_IARMBUS \
 -DENABLE_SYSTEM_GET_STORE_DEMO_LINK -DENABLE_DEEP_SLEEP \


### PR DESCRIPTION
…#116)

* RDKEMW-4139: Coverity integration with Entservices-inputoutput repo

Reason for change: Coverity integration with middleware component workflow Test Procedure: Verify checks in github
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com

* RDKEMW-4139: Coverity integration with Entservices-inputoutput repo

Reason for change: Coverity integration with middleware component workflow Test Procedure: Verify checks in github
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com

* RDKEMW-4139: Coverity integration with Entservices-inputoutput repo

Reason for change: Coverity integration with middleware component workflow Test Procedure: Verify checks in github
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com

* RDKEMW-4139: Coverity integration with Entservices-inputoutput repo 

Reason for change: Coverity integration with middleware component workflow Test Procedure: Verify checks in github
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com