### PR TITLE
RDKEMW-6230: Improper portNumber assignment

### DIFF
--- a/HdmiCecSink/HdmiCecSinkImplementation.cpp
+++ b/HdmiCecSink/HdmiCecSinkImplementation.cpp
@@ -1456,7 +1456,7 @@ namespace WPEFramework
                              break;
                          }
                     }
-                    actual_hdmicecdevices.powerStatus = hdmiPortNumber;
+                    actual_hdmicecdevices.portNumber = hdmiPortNumber;
                     localDevices.push_back(actual_hdmicecdevices);
                 }
             }


### PR DESCRIPTION
Reason for Change: Fix crash from GetDeviceList
Test Procedure: Check for crash
Risks: Low
Priority: P1