### PR TITLE
RDKEMW-6230: Retry logic used dsGetHDMIARCPortId in HdmiCecSink

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -3531,15 +3531,25 @@ namespace WPEFramework
       {
          int err;
          dsGetHDMIARCPortIdParam_t param;
-         err = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
-                            (char *)IARM_BUS_DSMGR_API_dsGetHDMIARCPortId,
-                            (void *)&param,
-                            sizeof(param));
-          if (IARM_RESULT_SUCCESS == err)
-          {
-             LOGINFO("HDMI ARC port ID HdmiArcPortID=[%d] \n", param.portId);
-             HdmiArcPortID = param.portId;
-          }
+         unsigned int retryCount = 1;
+         do {
+            usleep(50000); // Sleep for 50ms before retrying
+            param.portId = -1; // Initialize to an invalid port ID
+            err = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
+                                (char *)IARM_BUS_DSMGR_API_dsGetHDMIARCPortId,
+                                (void *)&param,
+                                sizeof(param));
+            if (IARM_RESULT_SUCCESS == err)
+            {
+                LOGINFO("HDMI ARC port ID HdmiArcPortID[%d] on retry count[%d]", param.portId, retryCount);
+                HdmiArcPortID = param.portId;
+                break;
+            }
+            else
+            {
+                LOGWARN("IARM_Bus_Call failed with error[%d], retry count[%d]", err, retryCount);
+            }
+        } while(retryCount++ <= 6);
       }
 
       void HdmiCecSink::getCecVersion()

--- a/Tests/L1Tests/tests/test_HdmiCecSink.cpp
+++ b/Tests/L1Tests/tests/test_HdmiCecSink.cpp
@@ -23,8 +23,6 @@
 #include <string>
 
 
-#include "HdmiCecSinkImplementation.h"
-#include "HdmiCecSinkMock.h"
 #include "HdmiCecSink.h"
 #include "FactoriesImplementation.h"
 #include "IarmBusMock.h"


### PR DESCRIPTION
RDKEMW-6230: Retry logic used dsGetHDMIARCPortId in HdmiCecSink

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>