### PR TITLE
RDKEMW-4778 : Automate git flow merges to main branch for entservices repos

### DIFF
--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -1,5 +1,8 @@
 name: Component Release
 
+permissions:
+  contents: write
+  
 on:
   pull_request:
     types: [closed]
@@ -9,7 +12,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true
-    runs-on: comcast-ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Reason for change: Any PRs merged to entservices repos should be updated in builds immediately else cause integration issue for other changes.
Test Procedure: Validate whether this workflow creates the tag as expected
Risks: Low
Version:Minor
Signed-off-by: Soundaryaa Sitaram<Soundaryaa_Sitaram@comcast.com>