### PR TITLE
RDKEMW-6515: Scan and Fix coverity issues of Entservices and rdkservices-cpc

### DIFF
--- a/HdmiCecSource/HdmiCecSourceImplementation.h
+++ b/HdmiCecSource/HdmiCecSourceImplementation.h
@@ -118,7 +118,7 @@ namespace WPEFramework {
 		std::unique_lock<std::mutex> lk;
 
 		CECDeviceInfo_2()
-		: m_logicalAddress(0),m_vendorID(0,0,0),m_osdName("NA"), m_isOSDNameUpdated (false), m_isVendorIDUpdated (false)
+		: m_logicalAddress(0),m_vendorID(0,0,0),m_osdName("NA"), m_deviceInfoStatus(0), m_isOSDNameUpdated (false), m_isVendorIDUpdated (false)
 		{
 			BITMASK_CLEAR(m_deviceInfoStatus, 0xFFFF); //Clear all bits
 		}


### PR DESCRIPTION
Reason for change: Fix Coverity identified issues in ENTServices-Infra Repo 
Test Procedure: Regression testing on effected plugins 
Risks: Low

Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com